### PR TITLE
Add separate icon component for react-native-vector-icons libraries

### DIFF
--- a/src/components/general/Icon.js
+++ b/src/components/general/Icon.js
@@ -1,0 +1,56 @@
+import React from "react";
+
+/**
+ * @desc Icon component from react-native-vector-icons.
+ *
+ * @typedef {Object} IconProps
+ * @prop {Number}                                     props.size   Icon size.
+ * @prop {String}                                     props.name   Icon name.
+ * @prop {String}                                     props.color  Icon color.
+ * @prop {'AntDesign' | 'Entypo' | 'EvilIcons'
+ *       |'Feather' | 'FontAwesome' | 'FontAwesome5'
+ *       | 'Fontisto' | 'Foundation' | 'Ionicons'
+ *       | 'MaterialIcons' | 'MaterialCommunityIcons'
+ *       | 'Octicons' | 'Zocial' | 'SimpleLineIcons'} [type=]      Type of icon component.
+ *
+ * @param {...IconProps}
+ */
+
+export const Icon = ({ type, ...props }) => {
+	let IconComponent = (() => {
+		switch (type) {
+			case "AntDesign":
+				return require("react-native-vector-icons/AntDesign").default;
+			case "Entypo":
+				return require("react-native-vector-icons/Entypo").default;
+			case "EvilIcons":
+				return require("react-native-vector-icons/EvilIcons").default;
+			case "Feather":
+				return require("react-native-vector-icons/Feather").default;
+			case "FontAwesome":
+				return require("react-native-vector-icons/FontAwesome").default;
+			case "FontAwesome5":
+				return require("react-native-vector-icons/FontAwesome5").default;
+			case "Fontisto":
+				return require("react-native-vector-icons/Fontisto").default;
+			case "Foundation":
+				return require("react-native-vector-icons/Foundation").default;
+			case "MaterialIcons":
+				return require("react-native-vector-icons/MaterialIcons").default;
+			case "MaterialCommunityIcons":
+				return require("react-native-vector-icons/MaterialCommunityIcons").default;
+			case "Octicons":
+				return require("react-native-vector-icons/Octicons").default;
+			case "Zocial":
+				return require("react-native-vector-icons/Zocial").default;
+			case "SimpleLineIcons":
+				return require("react-native-vector-icons/SimpleLineIcons").default;
+			default:
+				return require("react-native-vector-icons/Ionicons").default;
+		}
+	})();
+
+	return (
+		<IconComponent { ...props } />
+	);
+};

--- a/src/components/general/index.js
+++ b/src/components/general/index.js
@@ -5,6 +5,7 @@ export * from "./Button";
 export * from "./ButtonLayout";
 export * from "./DatePicker";
 export * from "./DraggableFlatList";
+export * from "./Icon";
 export * from "./FilterList";
 export * from "./Input";
 export * from "./NavBar";


### PR DESCRIPTION
<!--- What issue does this PR fix? Add the issue number next to '#'. If more than one, separate by commas and add additional hashes next to each issue. -->
Fixes #220 

## Description
<!--- In one to three sentences, describe what was changed in the code regarding the issue(s) tackled. -->
Created Icon "component" that groups all `react-native-vector-icons` bundled icons to allow the use of multiple icons from a single import.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other <!--- Specify below -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project found on [Contribution guidelines](https://github.com/SHPEUCF/shpeucfapp/wiki/Contribution-guidelines).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.